### PR TITLE
allow systemd service folder override and provide better default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ agent_location: /usr/local/bin
 config_location: /etc/grafana
 promtail_location: /opt/promtail
 install_unzip: true
+systemd_service_folder: /etc/systemd/system
 grafana_location: us-central1
 grafana_agent_config_template: agent-config.yaml.j2
 grafana_agent_systemd_template: grafana-agent.service.j2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,7 +37,7 @@
     - name: Template the new service file for Grafana agent
       template:
         src: "{{ grafana_agent_systemd_template }}"
-        dest: /usr/lib/systemd/system/grafana-agent.service
+        dest: "{{ systemd_service_folder }}/grafana-agent.service"
         mode: '0644'
 
     - name: Reload and start service Grafana agent

--- a/tasks/promtail.yml
+++ b/tasks/promtail.yml
@@ -31,7 +31,7 @@
     - name: Template the new service file for Promtail agent
       template:
         src: "{{ grafana_promtail_systemd_template }}"
-        dest: /usr/lib/systemd/system/promtail.service
+        dest: "{{ systemd_service_folder }}/promtail.service"
         mode: '0644'
 
     - name: Reload and start service Promtail agent


### PR DESCRIPTION
Hey there, thanks for the helpful role. A quick change to allow change to the destination folder for systemd services.

Also provide a better default destination (see https://stackoverflow.com/questions/40113964/how-can-i-install-a-systemd-service-using-ansible for ref/links). Stuff under `/usr/lib/systemd/system` should be kept for OS packaged stuff. User stuff should go under `/etc/systemd/system` (which also works on more platform, as `/usr/lib/systemd/system` does not exists by default on raspbian)

Let me know if you want any change :)