### PR TITLE
Replace type with grafana_agent_type

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # ansible_architecture
-type:
+grafana_agent_type:
   x86_64: amd64
   armv7l: armv7
   aarch64: arm64

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Download Agent file
   get_url:
-    url: "https://github.com/grafana/agent/releases/latest/download/agent-linux-{{ type[ansible_architecture] }}.zip"
+    url: "https://github.com/grafana/agent/releases/latest/download/agent-linux-{{ grafana_agent_type[ansible_architecture] }}.zip"
     dest: "/tmp/agent-linux.zip"
     mode: '0644'
 

--- a/templates/grafana-agent.service.j2
+++ b/templates/grafana-agent.service.j2
@@ -3,7 +3,7 @@ Description=Grafana Cloud agent
 
 [Service]
 Type=simple
-ExecStart={{ agent_location }}/agent-linux-{{ type[ansible_architecture] }} --config.file={{ config_location }}/agent-config.yaml
+ExecStart={{ agent_location }}/agent-linux-{{ grafana_agent_type[ansible_architecture] }} --config.file={{ config_location }}/agent-config.yaml
 Restart=always
 
 [Install]


### PR DESCRIPTION
Some roles (e.g. hcloud for managing cloud servers) set type during fact gathering colliding with the type dictionary in this role. This PR prevents name collision.