### PR TITLE
Allow the specification of custom service regions for Prometheus and Promtail

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ Each service in [Grafana Cloud](https://grafana.com/products/cloud/) has a uniqu
 
 Whether to install `unzip`, to extract files from agent's zip releases. By default is set to `true`.
 
-    grafana_location: us-central1
+    grafana_location_prometheus: us-central1
+    grafana_location_promtail: us-central1
 
-The closest Grafana region. As displayed in `@logs-prod-us-central1.grafana.net/api/prom/push` for example.
+The closest Grafana region for promtail or prometheus. As displayed in `@logs-prod-us-central1.grafana.net/api/prom/push` for example. By default `us-central1`
 
 To override the agent configuration template, you can define your own template. By default it'll source it from the role file `templates/agent-config.yaml.j2`. 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,7 +13,8 @@ config_location: /etc/grafana
 promtail_location: /opt/promtail
 install_unzip: true
 systemd_service_folder: /etc/systemd/system
-grafana_location: us-central1
+grafana_location_prometheus: us-central1
+grafana_location_promtail: us-central1
 grafana_agent_config_template: agent-config.yaml.j2
 grafana_agent_systemd_template: grafana-agent.service.j2
 grafana_promtail_config_template: promtail-config.yaml.j2

--- a/templates/agent-config.yaml.j2
+++ b/templates/agent-config.yaml.j2
@@ -9,7 +9,7 @@ integrations:
   node_exporter:
     enabled: true
   prometheus_remote_write:
-    - url: https://prometheus-{{ grafana_location }}.grafana.net/api/prom/push
+    - url: https://prometheus-{{ grafana_location_prometheus }}.grafana.net/api/prom/push
       basic_auth:
         username: "{{ prometheus_user }}"
         password: {{ grafana_api_key }}

--- a/templates/promtail-config.yaml.j2
+++ b/templates/promtail-config.yaml.j2
@@ -6,7 +6,7 @@ positions:
   filename: /tmp/positions.yaml
 
 client:
-  url: https://{{ loki_user }}:{{ grafana_api_key }}@logs-prod-{{ grafana_location }}.grafana.net/api/prom/push
+  url: https://{{ loki_user }}:{{ grafana_api_key }}@logs-prod-{{ grafana_location_promtail }}.grafana.net/api/prom/push
 
 scrape_configs:
 - job_name: log-files


### PR DESCRIPTION
Hello everyone! Thank you for providing this useful role!

This is a quick fix regarding the different service regions for Prometheus and Promtail.
Because the format may differ from each other as well as be in a totally different region (as in my case), I split them up into two different variables. This issue was already described in #8 by @spech66 who provided two solutions from which I picked one.

Wish you all an awesome Day!

![awesome](https://media.giphy.com/media/rY93u9tQbybks/giphy.gif)


