### PR TITLE
Move agent service reload into a handler

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,3 +4,9 @@
     name: grafana-agent
     state: restarted
     daemon_reload: true
+
+- name: Reload Promtail service
+  ansible.builtin.service:
+    name: promtail
+    state: restarted
+    daemon_reload: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Reload Grafana agent service
+  ansible.builtin.service:
+    name: grafana-agent
+    state: restarted
+    daemon_reload: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
   ansible.builtin.get_url:
     url: "https://github.com/grafana/agent/releases/latest/download/agent-linux-{{ grafana_agent_type[ansible_architecture] }}.zip"
     dest: "/tmp/agent-linux.zip"
-    mode: '0644'
+    mode: "0644"
 
 - name: Install unzip
   ansible.builtin.package:
@@ -16,7 +16,7 @@
     src: "/tmp/agent-linux.zip"
     dest: "{{ agent_location }}"
     remote_src: true
-    mode: '0755'
+    mode: "0755"
 
 - name: Create directory for Agent's config file
   ansible.builtin.file:
@@ -31,6 +31,7 @@
     dest: "{{ config_location }}/agent-config.yaml"
     mode: u=rw,g=r,o=r
     force: true
+    notify: Reload Grafana agent service
 
 - name: Create Systemd service
   block:
@@ -38,13 +39,13 @@
       ansible.builtin.template:
         src: "{{ grafana_agent_systemd_template }}"
         dest: "{{ systemd_service_folder }}/grafana-agent.service"
-        mode: '0644'
+        mode: "0644"
+        notify: Reload Grafana agent service
 
-    - name: Reload and start service Grafana agent
+    - name: Enable and start Grafana agent service
       ansible.builtin.service:
         name: grafana-agent
-        state: restarted
-        daemon_reload: true
+        state: started
         enabled: true
 
 - name: Install Promtail

--- a/tasks/promtail.yml
+++ b/tasks/promtail.yml
@@ -3,7 +3,7 @@
   ansible.builtin.get_url:
     url: "https://github.com/grafana/loki/releases/latest/download/promtail-linux-{{ promtail_type[ansible_architecture] }}.zip"
     dest: "/tmp/promtail-linux.zip"
-    mode: '0644'
+    mode: "0644"
 
 - name: Create directory for Promtail's files
   ansible.builtin.file:
@@ -17,7 +17,7 @@
     src: "/tmp/promtail-linux.zip"
     dest: "{{ promtail_location }}"
     remote_src: true
-    mode: '0755'
+    mode: "0755"
 
 - name: Create an Promtail config file
   ansible.builtin.template:
@@ -25,6 +25,7 @@
     dest: "{{ promtail_location }}/promtail-config.yaml"
     mode: u=rw,g=r,o=r
     force: true
+  notify: Reload Promtail service
 
 - name: Create Systemd service
   block:
@@ -32,11 +33,11 @@
       ansible.builtin.template:
         src: "{{ grafana_promtail_systemd_template }}"
         dest: "{{ systemd_service_folder }}/promtail.service"
-        mode: '0644'
+        mode: "0644"
+      notify: Reload Promtail service
 
     - name: Reload and start service Promtail agent
       ansible.builtin.service:
         name: promtail
-        state: restarted
-        daemon_reload: true
+        state: started
         enabled: true


### PR DESCRIPTION
This allows the role to run with no changes if the service or config template has not changed. If the service or config file has changed, the handler will be notified to restart the service.