### PR TITLE
agent-config: Remove deprecated server config

### DIFF
--- a/templates/agent-config.yaml.j2
+++ b/templates/agent-config.yaml.j2
@@ -1,5 +1,3 @@
-server:
-  http_listen_port: 12345
 prometheus:
   wal_directory: /tmp/grafana-agent-wal
   global:


### PR DESCRIPTION
The `server` block has been removed from the YAML config and causes the
agent to fail to start as of grafana-agent v0.26.

https://grafana.com/docs/agent/v0.26/upgrade-guide/#breaking-change-deprecated-yaml-fields-in-server-block-removed

Remove this field from the config to the config can be loaded. The port
will continue to be set properly as the command line flag defaults to
the same value as the previous config.