### PR TITLE
download: Fix URL for newer versions of agent file

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Download Agent file
   ansible.builtin.get_url:
-    url: "https://github.com/grafana/agent/releases/latest/download/agent-linux-{{ grafana_agent_type[ansible_architecture] }}.zip"
+    url: "https://github.com/grafana/agent/releases/latest/download/grafana-agent-linux-{{ grafana_agent_type[ansible_architecture] }}.zip"
     dest: "/tmp/agent-linux.zip"
     mode: "0644"
 


### PR DESCRIPTION
Grafana has changed their package urls to include "grafana" at the beginning of the package name. Update download URL to account for this.

Fixes: #17