### PR TITLE
Add molecule tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ None. But, Grafana Agent's configuration file has had some breaking changes rece
 
 See an example playbook I run for my home-lab [here](https://github.com/nleiva/ansible-home/blob/main/grafana-cloud.yml).
 
+## Testing
+
+The role is tested using [Molecule](https://molecule.readthedocs.io/en/latest/). Dependencies for testing are `podman` and its plugin for Molecule.
+
+Run `molecule test` in the repository root to test the role.
+
 ## License
 
 GPL-3.0 License

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,0 +1,22 @@
+---
+- name: Converge
+  hosts: all
+
+  vars:
+    # Bogus values to avoid failure in
+    # Grafana agent template rendering
+    prometheus_user: alice
+    grafana_api_key: bob
+
+  pre_tasks:
+    # Update the APT cache to prevent
+    # failue when installing unzip
+    - name: Update APT cache
+      when: ansible_os_family == "Debian"
+      ansible.builtin.apt:
+        update_cache: true
+
+  tasks:
+    - name: "Include ansible-role-grafana_agent"
+      ansible.builtin.include_role:
+        name: "ansible-role-grafana_agent"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,24 @@
+---
+dependency:
+  name: galaxy
+
+driver:
+  name: podman
+
+platforms:
+  - name: debian11
+    image: docker.io/geerlingguy/docker-debian11-ansible:latest
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    privileged: true
+    tmpfs:
+      - /run
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+
+provisioner:
+  name: ansible
+
+verifier:
+  name: ansible

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,8 +6,8 @@ driver:
   name: podman
 
 platforms:
-  - name: debian11
-    image: docker.io/geerlingguy/docker-debian11-ansible:latest
+  - name: debian
+    image: quay.io/nleiva/grafana-agent-role-debian
     pre_build_image: true
     command: /lib/systemd/systemd
     privileged: true

--- a/templates/grafana-agent.service.j2
+++ b/templates/grafana-agent.service.j2
@@ -3,7 +3,7 @@ Description=Grafana Cloud agent
 
 [Service]
 Type=simple
-ExecStart={{ agent_location }}/agent-linux-{{ grafana_agent_type[ansible_architecture] }} --config.file={{ config_location }}/agent-config.yaml
+ExecStart={{ agent_location }}/grafana-agent-linux-{{ grafana_agent_type[ansible_architecture] }} --config.file={{ config_location }}/agent-config.yaml
 Restart=always
 
 [Install]


### PR DESCRIPTION
This is the first PR for #19.

I've tested the Molecule settings in both Arch Linux and Ubuntu 22.04 (Vagrant VM).

I didn't want to change too much stuff in the role code to avoid having a larger PR. This is why I'm using "bogus" values for the Grafana auth variables. I plan on submitting changes to the agent template so we can avoid having calls to Grafana cloud without proper authentication values (in the future, after testing framework is in place).

However, I had to fix the systemd service file template, otherwise it would never start correctly.
Edit: this fixes https://github.com/nleiva/ansible-role-grafana_agent/issues/17.

I chose to use Podman instead of Docker because that's what I'm using to test my own roles. I can revert to Docker if you want me to.